### PR TITLE
Add Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 Bunction Package
 =================
 
+![Travis CI Badge](https://travis-ci.org/bunctions/pkg.svg?branch=master)
+
 This is a common package for building functions.


### PR DESCRIPTION
This pull request adds the Travis CI badge to README file. However, the real purpose of this pull request is to test Travis CI on pull request.
